### PR TITLE
chore(debug): disable meta loader during local debugging

### DIFF
--- a/.debug/inject.js
+++ b/.debug/inject.js
@@ -2,6 +2,15 @@
 (function () {
 	const bundleUrl = browser.runtime.getURL('bundled.js');
 	const SCRIPT_ID = 'citeforge-debug-userscript';
+	const DEV_STORAGE_KEY = 'citeforge-dev';
+
+	function markDevMode() {
+		if (localStorage.getItem(DEV_STORAGE_KEY) !== '1') {
+			localStorage.setItem(DEV_STORAGE_KEY, '1');
+		}
+	}
+
+	markDevMode();
 
 	function inject() {
 		// Create inline script that waits for mw.loader then loads our bundle
@@ -21,7 +30,7 @@
 
 					document.head.appendChild(script);
 				}
-				
+
 				if (typeof mw !== 'undefined' && mw.loader && typeof mw.loader.using === 'function') {
 					loadCiteForge();
 				} else {

--- a/.debug/manifest.json
+++ b/.debug/manifest.json
@@ -11,7 +11,7 @@
 			"js": [
 				"inject.js"
 			],
-			"run_at": "document_idle"
+			"run_at": "document_start"
 		}
 	],
 	"web_accessible_resources": [

--- a/README.md
+++ b/README.md
@@ -92,6 +92,26 @@ Tip: Update `url` in `.vscode/launch.json` if you want the debug session to star
 
 The first launch will create the profile folder if it does not exist; afterwards your cookies, localStorage, and other profile data persist automatically. Delete `.debug/firefox-profile` whenever you want a clean slate.
 
+### Disable the Meta-hosted loader while debugging
+
+If your user `common.js` (or `global.js`) loads the Meta-hosted script, add a guard to skip it when you are running the local debug extension:
+
+```js
+(() => {
+  const isDev = localStorage.getItem('citeforge-dev') === '1';
+  if (isDev) return;
+
+  mw.loader.load("//meta.wikimedia.org/w/index.php?title=User:SuperGrey/gadgets/CiteForge.js&action=raw&ctype=text/javascript");
+})();
+```
+
+The debug extension sets `localStorage["citeforge-dev"] = "1"` at `document_start`, so the remote loader is disabled for the debug profile. To restore the online version:
+
+```js
+localStorage.removeItem('citeforge-dev');
+location.reload();
+```
+
 ## Credits
 
 - Icons and assets from:


### PR DESCRIPTION
I think we can store a key-value pair `citeforge-dev` in localStorage, setting it to 1 during local debugging. Then, we can retrieve this value in `common.js` or `global.js`, and if it's 1, we won't load the remote scripts. This way, we can avoid the hassle of modifying `common.js` during debugging.