### PR TITLE
chore: refine floating citation popup translations

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -64,7 +64,7 @@
 	"ui.panel.harvLink": "Harv checks reference table",
 	"ui.panel.settings.title": "Cite Forge Settings",
 	"ui.panel.settings.copyFormat": "Copy ref name format",
-	"ui.panel.settings.showCopyPopup": "Show citation hover copy popup",
+	"ui.panel.settings.showCitationPopup": "Show citation hover popup (reload page to apply)",
 	"ui.panel.settings.enableUserNs": "Enable in User namespace",
 	"ui.panel.settings.placement": "Placement",
 	"ui.panel.settings.minUses": "Minimum uses for reflist",

--- a/src/i18n/zh-hans.json
+++ b/src/i18n/zh-hans.json
@@ -64,7 +64,7 @@
 	"ui.panel.harvLink": "哈佛文献格式检查参考表",
 	"ui.panel.settings.title": "Cite Forge 设置",
 	"ui.panel.settings.copyFormat": "复制引用名格式",
-	"ui.panel.settings.showCopyPopup": "显示引用悬停复制弹窗",
+	"ui.panel.settings.showCitationPopup": "显示引用悬停弹窗（重新加载页面以应用）",
 	"ui.panel.settings.enableUserNs": "允许在用户命名空间使用",
 	"ui.panel.settings.placement": "放置方式",
 	"ui.panel.settings.minUses": "移入参考列表的最少使用次数",

--- a/src/i18n/zh-hant.json
+++ b/src/i18n/zh-hant.json
@@ -64,7 +64,7 @@
 	"ui.panel.harvLink": "哈佛文獻格式檢查參考表",
 	"ui.panel.settings.title": "Cite Forge 設定",
 	"ui.panel.settings.copyFormat": "複製引用名格式",
-	"ui.panel.settings.showCopyPopup": "顯示引用懸浮複製提示",
+	"ui.panel.settings.showCitationPopup": "顯示引用懸浮提示（重新載入頁面以應用）",
 	"ui.panel.settings.enableUserNs": "允許在使用者命名空間啟用",
 	"ui.panel.settings.placement": "放置方式",
 	"ui.panel.settings.minUses": "移入參考列表的最少使用次數",

--- a/src/ui/panel.template.vue
+++ b/src/ui/panel.template.vue
@@ -200,7 +200,7 @@
 						</div>
 					</div>
 					<cdx-checkbox v-model="settings.showCiteRefCopyBtn">
-						{{ t('ui.panel.settings.showCopyPopup') }}
+						{{ t('ui.panel.settings.showCitationPopup') }}
 					</cdx-checkbox>
 					<cdx-checkbox v-model="settings.showInUserNs">
 						{{ t('ui.panel.settings.enableUserNs') }}
@@ -228,7 +228,8 @@
 					</cdx-checkbox>
 					<cdx-checkbox v-model="settings.allowCosmeticSaves">
 						<span>
-							<template v-for="(segment, idx) in tRich('ui.panel.settings.cosmeticSaves')" :key="`cosmetic-label-${idx}`">
+							<template v-for="(segment, idx) in tRich('ui.panel.settings.cosmeticSaves')"
+								:key="`cosmetic-label-${idx}`">
 								<a v-if="segment.type === 'link'" :href="segment.href" target="_blank" rel="noreferrer">
 									{{ segment.text }}
 								</a>


### PR DESCRIPTION
Refine citation popup translations. Some users mention that they don't know how to hide the floating popup, so we have to revise the label of the settings entry.